### PR TITLE
FIXED: issue #5 when the character stream contains any whitespace chars ...

### DIFF
--- a/src/main/scala/play/extras/iteratees/Combinators.scala
+++ b/src/main/scala/play/extras/iteratees/Combinators.scala
@@ -37,11 +37,12 @@ object Combinators {
     ch <- peekOne
     result <- ch match {
       case Some(c) if c == value => done(Unit)
-      case Some(c) => error("Expected '" + value + "' but got '" + c + "'")
+      case Some(c) => error("Expected '" + value + "' but got '"+ c +"' / chr(" + c.toInt + ")")
       case None => error("Premature end of input, expected '" + value + "'")
     }
     _ <- drop(1)
   } yield result
+
 
   def drop(n: Int): Iteratee[Array[Char], Unit] = Cont {
     case in @ EOF => Done(Unit, in)

--- a/src/test/scala/play/extras/iteratees/JsonSpec.scala
+++ b/src/test/scala/play/extras/iteratees/JsonSpec.scala
@@ -1,10 +1,9 @@
-package play.extras.iteratees
-
-import play.api.libs.json._
 import org.specs2.mutable.Specification
-import play.api.libs.iteratee.Enumerator
+import play.api.libs.iteratee._
 import concurrent.Await
 import concurrent.duration.Duration
+import play.api.libs.json._
+import play.extras.iteratees._
 
 object JsonSpec extends Specification {
   "json iteratee" should {
@@ -25,9 +24,45 @@ object JsonSpec extends Specification {
       "array" -> Json.arr(Json.obj("foo" -> "bar"), 20),
       "obj" -> Json.obj("one" -> 1, "two" -> 2, "nested" -> Json.obj("spam" -> "eggs"))
     ))
+    "parse a object out of a character enumerator with newlines using Enumeratee.grouped and Concurrent.broadcast" in testJsObjectWithWhitespaces()
+    "parse an array out of a character enumerator with newlines using Enumeratee.grouped and Concurrent.broadcast" in testJsArrayWithWhitespaces()
   }
 
   def test(json: JsValue) = {
     Await.result(Enumerator(Json.stringify(json).toCharArray) |>>> JsonIteratees.jsValue, Duration.Inf) must_== json
+  }
+
+
+  def testJsObjectWithWhitespaces() = {
+    val data = """
+    {"key1": "value1"} {"key2": "value2"}{"key3": 
+    "value3"} 
+
+    """.toCharArray
+    val (en, chann) = play.api.libs.iteratee.Concurrent.broadcast[Array[Char]]
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val res = (en &> Enumeratee.grouped(JsonIteratees.jsSimpleObject) |>>> Iteratee.getChunks)
+    chann.push(data)
+    chann.eofAndEnd()
+    Await.result(res, Duration.Inf).mkString must_== data.filterNot(_.isWhitespace).mkString
+  }
+
+  def testJsArrayWithWhitespaces() = {
+    val data = """
+    [1, 3, 4,5,
+    6,7
+    ,10,11, [0, 0, 0]
+
+    ]
+
+    """.toCharArray
+    val (en, chann) = play.api.libs.iteratee.Concurrent.broadcast[Array[Char]]
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val res = (en &> Enumeratee.grouped(JsonIteratees.jsSimpleArray) |>>> Iteratee.getChunks)
+    chann.push(data)
+    chann.eofAndEnd()
+    Await.result(res, Duration.Inf).mkString must_== data.filterNot(_.isWhitespace).mkString
   }
 }


### PR DESCRIPTION
this PR fixes issue #5 by dropping any whitespace before or after a complete jsArray or jsObject has been parsed. Basically it works like a `String.trim`
Added tests to JsonSpec for illustration.
